### PR TITLE
Use x86 python during win32 build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         os: [macos-11, ubuntu-22.04]
         addrsize: ["64"]
-        archive-format: "tzst"
+        archive-format: ["tzst"]
         python-architecture: ["x64"]
         include:
           - os: windows-2022
@@ -27,8 +27,8 @@ jobs:
       - uses: secondlife/action-autobuild@v3
         with:
           addrsize: ${{ matrix.addrsize }}
-          setup-python: false
           archive-format: ${{ matrix.archive-format }}
+          setup-python: false
   release:
     needs: build
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
Specify `python-architecture` as appropriate in build.yaml. This should fix win32 builds, which require a python interpreter of matching architecture.