### PR TITLE
SL-19756 Consistently use new standalone Python llsd package

### DIFF
--- a/src/leap.py
+++ b/src/leap.py
@@ -47,7 +47,7 @@ $/LicenseInfo$
 import errno
 import re
 import sys
-from llbase import llsd
+import llsd
 # We only expect to need one helper thread; the default is 20.
 import os
 os.environ['EVENTLET_THREADPOOL_SIZE'] = '2'

--- a/src/update_manager.py
+++ b/src/update_manager.py
@@ -32,7 +32,8 @@ $/LicenseInfo$
 from logging import DEBUG
 from util import Application, BuildData, SL_Logging, log_calls, pass_logger, subprocess_args, \
      put_marker_file, MergedSettings, ufile
-from llbase import llsd, llrest
+from llbase import llrest
+import llsd
 
 import apply_update
 from contextlib import suppress


### PR DESCRIPTION
The DRTVWR-582 (Maint U) incorporates some code from the xcode-14.3 branch, where the switch to using the llsd package (in place of llbase/llsd) occurred. 
Thus, this change is necessary for the correct interaction between the viewer and viewer-manager following the Maint U release.