### PR TITLE
SL-20031: Stop running Windows wmic; use PyPI wmi package instead.

### DIFF
--- a/build-cmd.py
+++ b/build-cmd.py
@@ -100,6 +100,10 @@ def main():
         # -U means: even if we already have an older version of (say) requests
         # in the system image, ensure our virtualenv has the version specified
         # in RUNTIME_DEPS (or the latest version if not version-locked).
+        # But first, update pip and ensure wheel is present: as of 2023-07-26,
+        # we couldn't install the cryptography package on Windows, possibly
+        # because of absence of wheel or a pip that was too old.
+        run(sys.executable, '-m', 'pip', 'install', '-U', 'pip', 'wheel')
         run(sys.executable, '-m', 'pip', 'install', '-U', *BUILD_DEPS.values())
     except RunError as err:
         raise Error(str(err)) from err

--- a/build-cmd.py
+++ b/build-cmd.py
@@ -202,9 +202,9 @@ def pyinstaller(mainfile, dstdir, icon, manifest_from_build=None):
     # PyInstaller, use the one in this directory.
     command.append('--additional-hooks-dir=' + os.path.dirname(__file__))
 
-    print_command('pyinstaller', *command)
     # https://pyinstaller.readthedocs.io/en/stable/usage.html#running-pyinstaller-from-python-code
     import PyInstaller.__main__
+    print_command(PyInstaller.__main__.__file__, *command)
     try:
         PyInstaller.__main__.run(command)
     except Exception as e:

--- a/build-cmd.py
+++ b/build-cmd.py
@@ -60,8 +60,11 @@ BUILD_DEPS = dict(
     requests='requests',
 )
 if system() == 'Windows':
-    BUILD_DEPS['cryptography'] = 'cryptography'
-    BUILD_DEPS['wmi'] = 'wmi'
+    BUILD_DEPS.update(
+        cryptography='cryptography',
+        pywintypes='pywintypes',
+        wmi='wmi',
+    )
 
 class Error(Exception):
     pass

--- a/build-cmd.py
+++ b/build-cmd.py
@@ -60,6 +60,7 @@ BUILD_DEPS = dict(
     requests='requests',
 )
 if system() == 'Windows':
+    BUILD_DEPS['cryptography'] = 'cryptography'
     BUILD_DEPS['wmi'] = 'wmi'
 
 class Error(Exception):

--- a/build-cmd.py
+++ b/build-cmd.py
@@ -62,7 +62,7 @@ BUILD_DEPS = dict(
 if system() == 'Windows':
     BUILD_DEPS.update(
         cryptography='cryptography',
-        pywintypes='pywintypes',
+        pywin32='pywin32',
         wmi='wmi',
     )
 


### PR DESCRIPTION
Remove wmic() and _wmic() functions, also WmicError.

Adjust tests accordingly. Delete test intentionally raising WmicError.

Also remove cruft concerning 32-bit Python.