### PR TITLE
Fix crash when Powershell query for MUUID is empty

### DIFF
--- a/src/update_manager.py
+++ b/src/update_manager.py
@@ -301,8 +301,14 @@ def make_VVM_UUID_hash(platform_key):
             #outputs row:
             #XXXXXXX-XXXX...
             # but splitlines() produces a whole lot of empty strings.
-            muuid = [line for line in muuid.splitlines() if line][-1].rstrip()
-            log.debug("result of subprocess call to get win MUUID: %r" % muuid)
+            muuid = [line for line in muuid.splitlines() if line]
+            if len(muuid) > 0:
+                muuid = muuid[-1].rstrip()
+                log.debug("result of subprocess call to get win MUUID: %r" % muuid)
+            else:
+                muuid = None
+                log.debug("pshell returned empty string when trying to get MUUID")
+
             
     if muuid is None:
         #fake it


### PR DESCRIPTION
Closes #20

Specifically:
This fixes the issue where if powershell returns a empty response (common in Wine environments), the updater will crash due to trying to access -1 in a empty array.