### PR TITLE
Create a stable fake MUUID instead of a random one

### DIFF
--- a/src/update_manager.py
+++ b/src/update_manager.py
@@ -307,7 +307,7 @@ def make_VVM_UUID_hash(platform_key):
     if muuid is None:
         #fake it
         log.info("Unable to get system unique id; constructing a dummy")
-        muuid = str(uuid.uuid1())
+        muuid = str(uuid.UUID(bytes=hashlib.md5(uuid.getnode().to_bytes(6)).digest()))
     # hashlib requires a bytes object, not a str
     hash = hashlib.md5(muuid.encode('utf8')).hexdigest()
     return hash

--- a/src/update_manager.py
+++ b/src/update_manager.py
@@ -307,7 +307,7 @@ def make_VVM_UUID_hash(platform_key):
     if muuid is None:
         #fake it
         log.info("Unable to get system unique id; constructing a dummy")
-        muuid = str(uuid.UUID(bytes=hashlib.md5(uuid.getnode().to_bytes(6)).digest()))
+        muuid = hashlib.md5(uuid.getnode().to_bytes(6)).hexdigest()
     # hashlib requires a bytes object, not a str
     hash = hashlib.md5(muuid.encode('utf8')).hexdigest()
     return hash


### PR DESCRIPTION
Discovered while fixing #20 

Specifically:
Currently, if MUUID is `None`, the VVM will generate a random UUID (UUIDv1 time based + mac address). My understanding is that MUUID is used for some sort of telemetry with the update server (Logging update success / failure rate?), as such environments that will fail to get the MUUID (such as wine) will continuously return a unique ID each update request.
This change modifies the way that MUUID is faked by using a md5 sum of the mac address as the UUID. This is similar to UUIDv1 where it is based off the mac address, but removes the time component to ensure that the UUID is stable across runs.